### PR TITLE
Fixes to improve compatibility and usability after some initial testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name to use on all resources created. | `string` | n/a |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID of the project in which Cloud Build is running. | `string` | n/a |
 | <a name="input_region"></a> [region](#input\_region) | The region in which to deploy the notifier service. | `string` | `"us-central1"` |
-| <a name="input_slack_webhook_url_secret_id"></a> [slack\_webhook\_url\_secret\_id](#input\_slack\_webhook\_url\_secret\_id) | The ID of an existing Google Secret Manager secret, containing a Slack webhook URL. | `string` | n/a |
+| <a name="input_slack_webhook_url_secret_id"></a> [slack\_webhook\_url\_secret\_id](#input\_slack\_webhook\_url\_secret\_id) | The ID of an existing Google Secret Manager secret, containing a Slack webhook URL. This is usually the `id` from the output of a `google_secret_manager_secret` resource. | `string` | n/a |
 | <a name="input_slack_webhook_url_secret_project"></a> [slack\_webhook\_url\_secret\_project](#input\_slack\_webhook\_url\_secret\_project) | The project ID containing the slack\_webhook\_url\_secret\_id. | `string` | n/a |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ No modules.
 | [google_storage_bucket.cloud_build_notifier](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_object.cloud_build_notifier_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [random_id.cloud_build_notifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.cloud_build_notifier_service](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_project.slack_webhook_url_secret_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_secret_manager_secret_version.slack_webhook_url](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
 

--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ To skip running the hooks when you commit:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.74 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 3.74 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.20 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.30 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.74 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 3.74 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.20 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.30 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ No modules.
 | [google_storage_bucket_object.cloud_build_notifier_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [random_id.cloud_build_notifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.cloud_build_notifier_service](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [google_project.slack_webhook_url_secret_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_secret_manager_secret_version.slack_webhook_url](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -27,18 +27,12 @@ resource "google_project_service" "apis" {
   disable_dependent_services = true
 }
 
-# Lookup the slack_webhook_url_secret_project so we can access the project number
-data "google_project" "slack_webhook_url_secret_project" {
-  project_id = var.slack_webhook_url_secret_project
-}
-
-
 # ------------------------------------------------------------------------------
 # Secrets
 # ------------------------------------------------------------------------------
 
 data "google_secret_manager_secret_version" "slack_webhook_url" {
-  project = data.google_project.slack_webhook_url_secret_project.number
+  project = var.slack_webhook_url_secret_project
   secret  = var.slack_webhook_url_secret_id
 }
 
@@ -68,7 +62,8 @@ resource "google_project_iam_member" "notifier_project_roles" {
 
 # Give the notifier service account access to the secret
 resource "google_secret_manager_secret_iam_member" "notifier_secret_accessor" {
-  secret_id = data.google_secret_manager_secret_version.slack_webhook_url.secret
+  project   = var.slack_webhook_url_secret_project
+  secret_id = var.slack_webhook_url_secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.notifier.email}"
 

--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,6 @@ resource "google_secret_manager_secret_iam_member" "notifier_secret_accessor" {
   secret_id = var.slack_webhook_url_secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.notifier.email}"
-
-  depends_on = [
-    google_project_service.apis
-  ]
 }
 
 # Look up the pubsub SA
@@ -192,6 +188,11 @@ resource "google_cloud_run_service" "cloud_build_notifier" {
       metadata.0.annotations,
     ]
   }
+
+  depends_on = [
+    google_project_service.apis["run.googleapis.com"],
+    google_secret_manager_secret_iam_member.notifier_secret_accessor
+  ]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Cloud Build Notifier
 
 locals {
-  base_name = "cbnotify-${var.name}"
+  base_name = "cbn-${var.name}"
 }
 
 
@@ -49,7 +49,7 @@ data "google_secret_manager_secret_version" "slack_webhook_url" {
 
 # Create cloud build notifier service account
 resource "google_service_account" "notifier" {
-  account_id = "${local.base_name}-notifier"
+  account_id = "${local.base_name}-nfy"
   project    = var.project_id
 }
 
@@ -93,7 +93,7 @@ resource "google_project_iam_member" "pubsub_project_roles" {
 
 # Create a pub/sub invoker service account
 resource "google_service_account" "pubsub_invoker" {
-  account_id = "${local.base_name}-pubsub"
+  account_id = "${local.base_name}-pbs"
   project    = var.project_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "name" {
 }
 
 variable "slack_webhook_url_secret_id" {
-  description = "The ID of an existing Google Secret Manager secret, containing a Slack webhook URL."
+  description = "The ID of an existing Google Secret Manager secret, containing a Slack webhook URL. This is usually the `id` from the output of a `google_secret_manager_secret` resource."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("[a-z0-9-]{0,30}", var.name))
+    condition     = can(regex("[a-z0-9-]{0,20}", var.name))
     error_message = "A name must be lowercase letters, numbers, or -."
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,17 +3,17 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74"
+      version = ">= 3.20"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74"
+      version = ">= 3.30"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = ">= 2.1"
     }
   }
 }


### PR DESCRIPTION
I identified some issues after testing this module in conjunction with Google's project-factory. I'm also making a few changes here to improve the usability of the module.

**Changes:**
- https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/commit/c923a14eb91294878830498ce0c88e2f7e7c9653: Pinned versions of the google provider in this module sometimes conflicted when used in conjunction with google project-factory
- https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/commit/0d1b7916f6061a750f5b052232e8b8340f7389f0: Shorten the prefixes and suffixes of resource names to allow for longer user-inputted names
- https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/commit/143fa5adb21ce4760afef405497d2f092307aae8: Avoid appending crc directly to service name by using `random_id` keepers
- https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/commit/ff240715312449e399b02711abf0f0acc54a7716: Passing in a secret ID and project would sometimes error with a mismatch, cleaned up the resources to be more consistent
- https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/commit/ff312cc72043c54e010a9bd2286f53bb7a310e11: Updated variable description for secret ID to be clearer
- https://github.com/simplifi/terraform-google-cloud-build-slack-notifier/commit/f5f5cb577e865af9f1d8909bc15e6bacf033f8b8: Set explicit `depends_on` to handle occasional cases where API enablement runs slow, resulting in the notifier service failing to start