### PR TITLE
Fix failed clone for pre-commit in Travis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-merge-conflict
-- repo: git://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.50.0
   hooks:
     - id: terraform_fmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ install:
   - pip install pre-commit
 
   # Install terraform
-  - curl -Lo terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-  - unzip terraform.zip
-  - mv terraform ${HOME}/bin/terraform
+  - curl -Lo /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+  - unzip /tmp/terraform.zip
+  - mv /tmp/terraform ${HOME}/bin/terraform
 
   # Install terraform-docs
-  - curl -Lo ./terraform-docs.tar.gz "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
-  - tar -xzf terraform-docs.tar.gz
-  - mv terraform-docs ${HOME}/bin/terraform-docs
+  - curl -Lo /tmp/terraform-docs.tar.gz "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
+  - tar -xzf /tmp/terraform-docs.tar.gz
+  - mv /tmp/terraform-docs ${HOME}/bin/terraform-docs
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 
   # Install terraform
   - curl -Lo /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-  - unzip /tmp/terraform.zip
+  - unzip /tmp/terraform.zip -d /tmp/
   - mv /tmp/terraform ${HOME}/bin/terraform
 
   # Install terraform-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: python
 
 env:
-- TERRAFORM_VERSION=1.0.2 TERRAFORM_DOCS_VERSION=0.14.1
+- TERRAFORM_VERSION=1.0.2 TERRAFORM_DOCS_VERSION=0.16.0
 
 install:
   # Install pre-commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 
   # Install terraform-docs
   - curl -Lo /tmp/terraform-docs.tar.gz "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
-  - tar -xzf /tmp/terraform-docs.tar.gz
+  - tar -xzf /tmp/terraform-docs.tar.gz -C /tmp/
   - mv /tmp/terraform-docs ${HOME}/bin/terraform-docs
 
 jobs:


### PR DESCRIPTION
Pre-commit is failing in Travis because we put `git://` in the config instead of `https://`. This should fix the builds.