### PR TITLE
Use uniform bucket level access on storage bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,10 +106,10 @@ resource "random_id" "cloud_build_notifier" {
 }
 
 resource "google_storage_bucket" "cloud_build_notifier" {
-  project       = var.project_id
-  name          = "${local.base_name}-${random_id.cloud_build_notifier.hex}"
-  force_destroy = true
-  location      = var.region
+  project                     = var.project_id
+  name                        = "${local.base_name}-${random_id.cloud_build_notifier.hex}"
+  force_destroy               = true
+  location                    = var.region
   uniform_bucket_level_access = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ resource "google_storage_bucket" "cloud_build_notifier" {
   name          = "${local.base_name}-${random_id.cloud_build_notifier.hex}"
   force_destroy = true
   location      = var.region
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "cloud_build_notifier_config" {


### PR DESCRIPTION
The requirement to use uniform bucket level access is a common organizational policy enforcement. Setting this to be explicitly true allows this terraform script to be used in projects with this policy.

https://cloud.google.com/storage/docs/uniform-bucket-level-access