### PR TITLE
Redeploy Cloud Run upon Slack Template File Changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ resource "google_storage_bucket_object" "cloud_build_notifier_config" {
 resource "random_id" "cloud_build_notifier_service" {
   # We use a keeper here so we can force cloud run to redeploy on script change.
   keepers = {
-    script_hash = google_storage_bucket_object.cloud_build_notifier_config.md5hash
+    script_hash         = google_storage_bucket_object.cloud_build_notifier_config.md5hash
     slack_template_hash = google_storage_bucket_object.slack_template.md5hash
   }
 

--- a/main.tf
+++ b/main.tf
@@ -165,6 +165,7 @@ resource "random_id" "cloud_build_notifier_service" {
   # We use a keeper here so we can force cloud run to redeploy on script change.
   keepers = {
     script_hash = google_storage_bucket_object.cloud_build_notifier_config.md5hash
+    slack_template_hash = google_storage_bucket_object.slack_template.md5hash
   }
 
   byte_length = 4


### PR DESCRIPTION
Added slack template hash to cloud run keeper so that cloud run is redeployed upon changes in the file.